### PR TITLE
feat: Implement initial iOS translate screen using KMM shared logic

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		A47A503A2F48F8C600153599 /* LanguageDropdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47A50392F48F8C600153599 /* LanguageDropdown.swift */; };
 		A47A503C2F48FEAC00153599 /* SmallLanguageIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47A503B2F48FEAC00153599 /* SmallLanguageIcon.swift */; };
 		A47A503E2F48FFD300153599 /* SwapLanguageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47A503D2F48FFD300153599 /* SwapLanguageButton.swift */; };
-		A47A50402F4900FB00153599 /* TranslateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47A503F2F4900FB00153599 /* TranslateViewModel.swift */; };
+		A47A50402F4900FB00153599 /* IOSTranslateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47A503F2F4900FB00153599 /* IOSTranslateViewModel.swift */; };
 		A47A50422F49011800153599 /* TranslateScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47A50412F49011800153599 /* TranslateScreen.swift */; };
 /* End PBXBuildFile section */
 
@@ -35,7 +35,7 @@
 		A47A50392F48F8C600153599 /* LanguageDropdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageDropdown.swift; sourceTree = "<group>"; };
 		A47A503B2F48FEAC00153599 /* SmallLanguageIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallLanguageIcon.swift; sourceTree = "<group>"; };
 		A47A503D2F48FFD300153599 /* SwapLanguageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapLanguageButton.swift; sourceTree = "<group>"; };
-		A47A503F2F4900FB00153599 /* TranslateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateViewModel.swift; sourceTree = "<group>"; };
+		A47A503F2F4900FB00153599 /* IOSTranslateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSTranslateViewModel.swift; sourceTree = "<group>"; };
 		A47A50412F49011800153599 /* TranslateScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateScreen.swift; sourceTree = "<group>"; };
 		F8CE67D4F4ED04B88D562F5D /* Pods-iosApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.release.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -128,7 +128,7 @@
 			isa = PBXGroup;
 			children = (
 				A47A50362F48B92B00153599 /* components */,
-				A47A503F2F4900FB00153599 /* TranslateViewModel.swift */,
+				A47A503F2F4900FB00153599 /* IOSTranslateViewModel.swift */,
 				A47A50412F49011800153599 /* TranslateScreen.swift */,
 			);
 			path = presentation;
@@ -296,7 +296,7 @@
 				A47A503C2F48FEAC00153599 /* SmallLanguageIcon.swift in Sources */,
 				A47A503A2F48F8C600153599 /* LanguageDropdown.swift in Sources */,
 				A47A503E2F48FFD300153599 /* SwapLanguageButton.swift in Sources */,
-				A47A50402F4900FB00153599 /* TranslateViewModel.swift in Sources */,
+				A47A50402F4900FB00153599 /* IOSTranslateViewModel.swift in Sources */,
 				A47A50382F48B94C00153599 /* LanguageDropdownItem.swift in Sources */,
 				A47A50422F49011800153599 /* TranslateScreen.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -2,10 +2,13 @@ import SwiftUI
 import shared
 
 struct ContentView: View {
-    let greet = Greeting().greet()
+    private let appModule = AppModule()
 
 	var body: some View {
-		Text(greet)
+        TranslateScreen(
+            historyDataSource: appModule.historyDataSource,
+            translateUseCase: appModule.translateUseCase,
+        )
 	}
 }
 

--- a/iosApp/iosApp/translate/presentation/IOSTranslateViewModel.swift
+++ b/iosApp/iosApp/translate/presentation/IOSTranslateViewModel.swift
@@ -10,9 +10,10 @@ import Foundation
 import shared
 
 extension TranslateScreen {
-    @MainActor class TranslateViewModel: ObservableObject {
+    @MainActor class IOSTranslateViewModel: ObservableObject {
         private var historyDataSource: HistoryDataSource
         private var translateUseCase: TranslateUseCase
+        
         private let viewModel : TranslateViewModel
         
         @Published var state: TranslateState = TranslateState(
@@ -27,24 +28,32 @@ extension TranslateScreen {
             history: []
         )
         
-        private var handle: DisposableHandle?
+        private var handle: (any Kotlinx_coroutines_coreDisposableHandle)?
         
         init(historyDataSource: HistoryDataSource, translateUseCase: TranslateUseCase) {
             self.historyDataSource = historyDataSource
             self.translateUseCase = translateUseCase
-            self.viewModel = TranslateViewModel(historyDataSource: historyDataSource, translateUseCase: translateUseCase)
+            self.viewModel = TranslateViewModel(
+                translateUseCase: translateUseCase,
+                historyDataSource: historyDataSource,
+                coroutineScope: nil,
+            )
         }
         
         func onEvent(event: TranslateEvent) {
-                   self.viewModel.onEvent(event: event)
-               }
+            self.viewModel.onEvent(event: event)
+        }
                
-               func startObserving() {
-                   handle = viewModel.state.collec
-               }
+       func startObserving() {
+           handle = viewModel.state.subscribe(onCollect: {state in
+               if let state = state {
+                    self.state = state
+                }
+           })
+       }
                
-               func dispose() {
-                   handle?.dispose()
-               }
+       func dispose() {
+           handle?.dispose()
+       }
     }
 }

--- a/iosApp/iosApp/translate/presentation/TranslateScreen.swift
+++ b/iosApp/iosApp/translate/presentation/TranslateScreen.swift
@@ -7,13 +7,58 @@
 //
 
 import SwiftUI
+import shared
 
 struct TranslateScreen: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    
+    private var historyDataSource: HistoryDataSource
+    private var translateUseCase: TranslateUseCase
+    @ObservedObject var viewModel: IOSTranslateViewModel
+    
+    init(historyDataSource: HistoryDataSource, translateUseCase: TranslateUseCase) {
+        self.historyDataSource = historyDataSource
+        self.translateUseCase = translateUseCase
+        self.viewModel = IOSTranslateViewModel(historyDataSource: historyDataSource, translateUseCase: translateUseCase)
     }
-}
-
-#Preview {
-    TranslateScreen()
+    
+    
+    var body: some View {
+        ZStack {
+            List {
+                HStack(alignment: .center) {
+                    LanguageDropdown(
+                        language: viewModel.state.fromLanguage,
+                        isOpen: viewModel.state.isChoosingFromLanguage,
+                        selectedLanguage: { language in
+                            viewModel.onEvent(event: TranslateEvent.ChooseFromLanguage(language: language))
+                        }
+                    )
+                    Spacer()
+                    SwapLanguageButton(
+                        onClick: {
+                            viewModel.onEvent(event: TranslateEvent.SwapLanguages())
+                        }
+                    )
+                    Spacer()
+                    LanguageDropdown(
+                        language: viewModel.state.toLanguage,
+                        isOpen: viewModel.state.isChoosingToLanguage,
+                        selectedLanguage: { language in
+                            viewModel.onEvent(event: TranslateEvent.ChooseToLanguage(language: language))
+                        }
+                    )
+                }
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.background)
+            }
+            .listStyle(.plain)
+            .buttonStyle(.plain)
+        }
+        .onAppear {
+            viewModel.startObserving()
+        }
+        .onDisappear {
+            viewModel.dispose()
+        }
+    }
 }

--- a/iosApp/iosApp/translate/presentation/components/SwapLanguageButton.swift
+++ b/iosApp/iosApp/translate/presentation/components/SwapLanguageButton.swift
@@ -15,7 +15,7 @@ struct SwapLanguageButton: View {
     
     var body: some View {
         Button(action: onClick){
-            Image(uiImage: UIImage(named: "swipe_languages")!)
+            Image(uiImage: UIImage(named: "swap_languages")!)
                 .padding()
                 .background(Color.primaryColor)
                 .clipShape(Circle())

--- a/rebuild_ios_framework.sh
+++ b/rebuild_ios_framework.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
+IOS_APP="$PROJECT_ROOT/iosApp"
+
+echo "==> Cleaning shared module..."
+"$PROJECT_ROOT/gradlew" :shared:clean
+
+echo "==> Building Kotlin/Native framework..."
+"$PROJECT_ROOT/gradlew" :shared:podPublishDebugXCFramework
+
+echo "==> Re-installing CocoaPods..."
+cd "$IOS_APP"
+pod install
+
+echo ""
+echo "Done. Now open Xcode, do Product → Clean Build Folder (⇧⌘K), then Build (⌘B)."

--- a/shared/src/commonMain/kotlin/com/enzoftware/translatorapp/core/util/CommonFlow.kt
+++ b/shared/src/commonMain/kotlin/com/enzoftware/translatorapp/core/util/CommonFlow.kt
@@ -1,7 +1,10 @@
 package com.enzoftware.translatorapp.core.util
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 
-expect class CommonFlow<T>(flow: Flow<T>)
+expect class CommonFlow<T>(flow: Flow<T>) : Flow<T> {
+    override suspend fun collect(collector: FlowCollector<T>)
+}
 
 fun <T> Flow<T>.toCommonFlow() = CommonFlow(this)

--- a/shared/src/commonMain/kotlin/com/enzoftware/translatorapp/core/util/CommonStateFlow.kt
+++ b/shared/src/commonMain/kotlin/com/enzoftware/translatorapp/core/util/CommonStateFlow.kt
@@ -1,7 +1,14 @@
 package com.enzoftware.translatorapp.core.util
 
+import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.StateFlow
 
-expect class CommonStateFlow<T>(flow: StateFlow<T>)
+@OptIn(ExperimentalForInheritanceCoroutinesApi::class)
+expect class CommonStateFlow<T>(flow: StateFlow<T>) : StateFlow<T> {
+    override val value: T
+    override suspend fun collect(collector: FlowCollector<T>): Nothing
+    override val replayCache: List<T>
+}
 
 fun <T> StateFlow<T>.toCommonStateFlow() = CommonStateFlow(this)

--- a/shared/src/iosMain/kotlin/com/enzoftware/translatorapp/core/util/CommonFlow.kt
+++ b/shared/src/iosMain/kotlin/com/enzoftware/translatorapp/core/util/CommonFlow.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.DisposableHandle
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch

--- a/shared/src/iosMain/kotlin/com/enzoftware/translatorapp/core/util/CommonStateFlow.kt
+++ b/shared/src/iosMain/kotlin/com/enzoftware/translatorapp/core/util/CommonStateFlow.kt
@@ -9,13 +9,13 @@ actual open class CommonStateFlow<T> actual constructor(
     private val flow: StateFlow<T>,
 ) : CommonFlow<T>(flow), StateFlow<T> by flow {
 
-    override val value: T
+    actual override val value: T
         get() = flow.value
 
-    override val replayCache: List<T>
+    actual override val replayCache: List<T>
         get() = flow.replayCache
 
-    override suspend fun collect(collector: FlowCollector<T>): Nothing {
+    actual override suspend fun collect(collector: FlowCollector<T>): Nothing {
         flow.collect(collector)
     }
 }

--- a/shared/src/iosMain/kotlin/com/enzoftware/translatorapp/di/AppModule.kt
+++ b/shared/src/iosMain/kotlin/com/enzoftware/translatorapp/di/AppModule.kt
@@ -1,0 +1,31 @@
+package com.enzoftware.translatorapp.di
+
+import com.enzoftware.translatorapp.TranslatorDatabase
+import com.enzoftware.translatorapp.translate.data.history.SqlDelightHistoryDataSource
+import com.enzoftware.translatorapp.translate.data.local.DatabaseDriverFactory
+import com.enzoftware.translatorapp.translate.data.remote.HttpClientFactory
+import com.enzoftware.translatorapp.translate.data.translate.KtorTranslateClient
+import com.enzoftware.translatorapp.translate.domain.history.HistoryDataSource
+import com.enzoftware.translatorapp.translate.domain.translate.TranslateClient
+import com.enzoftware.translatorapp.translate.domain.translate.TranslateUseCase
+import io.ktor.client.HttpClient
+
+class AppModule {
+    val historyDataSource: HistoryDataSource by lazy {
+        SqlDelightHistoryDataSource(
+            TranslatorDatabase(
+                DatabaseDriverFactory().create()
+            )
+        )
+    }
+
+    private val translateClient: TranslateClient by lazy {
+        KtorTranslateClient(
+            HttpClientFactory().create()
+        )
+    }
+
+    val translateUseCase: TranslateUseCase by lazy {
+        TranslateUseCase(translateClient, historyDataSource)
+    }
+}


### PR DESCRIPTION
This pull request refactors the iOS app's translation feature by updating the ViewModel naming and usage, improving SwiftUI integration, and enhancing Kotlin Multiplatform support for flows and state flows. It also introduces a new dependency injection module for easier access to core use cases and data sources. The changes streamline cross-platform code and modernize the app's architecture.

### iOS Presentation Layer Refactor

* Renamed `TranslateViewModel.swift` to `IOSTranslateViewModel.swift` and updated all references in `iosApp.xcodeproj` and presentation layer to use the new name, clarifying platform-specific responsibilities. [[1]](diffhunk://#diff-3128a88752afa7f03b453c0c30cbc563d3998b87fc54a1267bd1f1c943341d87L20-R20) [[2]](diffhunk://#diff-3128a88752afa7f03b453c0c30cbc563d3998b87fc54a1267bd1f1c943341d87L38-R38) [[3]](diffhunk://#diff-3128a88752afa7f03b453c0c30cbc563d3998b87fc54a1267bd1f1c943341d87L131-R131) [[4]](diffhunk://#diff-3128a88752afa7f03b453c0c30cbc563d3998b87fc54a1267bd1f1c943341d87L299-R299) [[5]](diffhunk://#diff-bdabf87a47a7aed695a98ead58da0ae71169c01bf793e1e6a290c2cf13a7485eL13-R16)
* Updated `TranslateScreen.swift` to use dependency injection for `historyDataSource` and `translateUseCase` via the new `AppModule`, and replaced the preview with actual usage of these dependencies. [[1]](diffhunk://#diff-bf67e5b843e95736ad585d504f2c059353814598576280ed2456ac4571467c35R10-L18) [[2]](diffhunk://#diff-aa4e2052b22ab2454329f9761c75169e801d78127b9849bd18ed3d1e31c447aaL5-R11)

### Kotlin Multiplatform Flow Improvements

* Updated `CommonFlow` and `CommonStateFlow` to inherit from their respective interfaces and provide proper overrides for `collect`, `value`, and `replayCache`, improving interoperability and state management across platforms. [[1]](diffhunk://#diff-cbc9e45e71e003172e7a9e3c946a83a37c7007038511bd7dbf7317d167881eaeR4-R8) [[2]](diffhunk://#diff-b5e613ba6f65ba0b34b6a02c48954817d43d6a63432f69d88e35956437bf8e35R3-R12) [[3]](diffhunk://#diff-3f3b8a6b51f7866147cbd667b820ff7eca2948b74e67682d7ff44822039bd9f9L12-R18) [[4]](diffhunk://#diff-24aed8257338a749e8cee0312ed053d1ee1e31fff0cf4fb1b82036b2a8d68b64R7)

### Dependency Injection

* Added `AppModule.kt` in `shared/src/iosMain/kotlin/com/enzoftware/translatorapp/di` to centralize creation of `HistoryDataSource` and `TranslateUseCase`, simplifying dependency management in the iOS app.

### UI Improvements

* Fixed image resource name in `SwapLanguageButton.swift` from `"swipe_languages"` to `"swap_languages"` for correct asset usage.

### Build Tooling

* Introduced `rebuild_ios_framework.sh` script to automate cleaning, building, and CocoaPods installation for the shared Kotlin/Native framework, streamlining developer workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive translation screen with language selection dropdowns and language swap functionality to the main app view.

* **Chores**
  * Introduced automated iOS framework rebuild script for streamlined development workflows.
  * Updated asset naming for visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->