### PR TITLE
feat: Implement translation history display

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		A4FFAF322F4C111200488508 /* ProgressButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4FFAF312F4C111200488508 /* ProgressButton.swift */; };
 		A4FFAF342F4C12AA00488508 /* TranslateTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4FFAF332F4C12AA00488508 /* TranslateTextField.swift */; };
 		A4FFAF362F4C1CC700488508 /* TextToSpeech.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4FFAF352F4C1CC700488508 /* TextToSpeech.swift */; };
+		A4FFAF382F4C208200488508 /* TranslateHistoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4FFAF372F4C208200488508 /* TranslateHistoryItem.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -47,6 +48,7 @@
 		A4FFAF312F4C111200488508 /* ProgressButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressButton.swift; sourceTree = "<group>"; };
 		A4FFAF332F4C12AA00488508 /* TranslateTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateTextField.swift; sourceTree = "<group>"; };
 		A4FFAF352F4C1CC700488508 /* TextToSpeech.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextToSpeech.swift; sourceTree = "<group>"; };
+		A4FFAF372F4C208200488508 /* TranslateHistoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateHistoryItem.swift; sourceTree = "<group>"; };
 		F8CE67D4F4ED04B88D562F5D /* Pods-iosApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.release.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -156,6 +158,7 @@
 				A4FFAF312F4C111200488508 /* ProgressButton.swift */,
 				A4FFAF332F4C12AA00488508 /* TranslateTextField.swift */,
 				A4FFAF352F4C1CC700488508 /* TextToSpeech.swift */,
+				A4FFAF372F4C208200488508 /* TranslateHistoryItem.swift */,
 			);
 			path = components;
 			sourceTree = "<group>";
@@ -319,6 +322,7 @@
 				A47A50422F49011800153599 /* TranslateScreen.swift in Sources */,
 				A4FFAF362F4C1CC700488508 /* TextToSpeech.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
+				A4FFAF382F4C208200488508 /* TranslateHistoryItem.swift in Sources */,
 				A4FFAF342F4C12AA00488508 /* TranslateTextField.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -5,10 +5,15 @@ struct ContentView: View {
     private let appModule = AppModule()
 
 	var body: some View {
-        TranslateScreen(
-            historyDataSource: appModule.historyDataSource,
-            translateUseCase: appModule.translateUseCase,
-        )
+        // Set background color for the whole app
+        ZStack{
+            Color.background.ignoresSafeArea()
+            TranslateScreen(
+                historyDataSource: appModule.historyDataSource,
+                translateUseCase: appModule.translateUseCase,
+            )
+        }
+       
 	}
 }
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -4,21 +4,21 @@ import shared
 struct ContentView: View {
     private let appModule = AppModule()
 
-	var body: some View {
+    var body: some View {
         // Set background color for the whole app
-        ZStack{
+        ZStack {
             Color.background.ignoresSafeArea()
             TranslateScreen(
                 historyDataSource: appModule.historyDataSource,
                 translateUseCase: appModule.translateUseCase,
             )
         }
-       
-	}
+
+    }
 }
 
 struct ContentView_Previews: PreviewProvider {
-	static var previews: some View {
-		ContentView()
-	}
+    static var previews: some View {
+        ContentView()
+    }
 }

--- a/iosApp/iosApp/core/presentation/Colors.swift
+++ b/iosApp/iosApp/core/presentation/Colors.swift
@@ -11,47 +11,47 @@ import SwiftUI
 import shared
 
 extension Color {
-    init(hex: Int64, alpha: Double = 1){
+    init(hex: Int64, alpha: Double = 1) {
         self.init(
             .sRGB,
             red: Double((hex >> 16) & 0xff) / 255,
-            green:  Double((hex >> 16) & 0xff) / 255,
+            green: Double((hex >> 16) & 0xff) / 255,
             blue: Double((hex >> 16) & 0xff) / 255,
             opacity: alpha
         )
     }
-    
+
     private static let colors = Colors()
-    
+
     static let lightBlue = Color(hex: colors.LightBlue)
     static let lightBlueGrey = Color(hex: colors.LightBlueGrey)
-    
+
     static let accentViolet = Color(hex: colors.AccentViolet)
     static let textBlack = Color(hex: colors.TextBlack)
     static let darkGrey = Color(hex: colors.DarkGrey)
-    
+
     static let primaryColor = Color(light: .accentViolet, dark: .accentViolet)
     static let background = Color(light: .lightBlueGrey, dark: .darkGrey)
-    static let onPrimary = Color(light: .white , dark: .white)
+    static let onPrimary = Color(light: .white, dark: .white)
     static let onBackground = Color(light: .textBlack, dark: .white)
     static let surface = Color(light: .white, dark: .darkGrey)
     static let onSurface = Color(light: .textBlack, dark: .white)
-    
+
 }
 
-private extension Color {
-    init(light: Self, dark: Self){
+extension Color {
+    fileprivate init(light: Self, dark: Self) {
         self.init(uiColor: UIColor(light: UIColor(light), dark: UIColor(dark)))
     }
 }
 
-private extension UIColor {
-    convenience init(light: UIColor, dark: UIColor){
+extension UIColor {
+    fileprivate convenience init(light: UIColor, dark: UIColor) {
         self.init { traits in
             switch traits.userInterfaceStyle {
-                case .light, .unspecified: return light
-                case .dark: return dark
-                default: return light
+            case .light, .unspecified: return light
+            case .dark: return dark
+            default: return light
             }
         }
     }

--- a/iosApp/iosApp/core/presentation/GradientSurface.swift
+++ b/iosApp/iosApp/core/presentation/GradientSurface.swift
@@ -10,12 +10,12 @@ import SwiftUI
 
 struct GradientSurface: ViewModifier {
     @Environment(\.colorScheme) var colorScheme
-    
+
     func body(content: Content) -> some View {
         if colorScheme == .dark {
-            let gradientStart = Color(hex: 0xFF23262E)
-            let gradientEnd = Color(hex: 0xFF212329)
-            
+            let gradientStart = Color(hex: 0xFF23_262E)
+            let gradientEnd = Color(hex: 0xFF21_2329)
+
             content.background(
                 LinearGradient(
                     gradient: Gradient(colors: [gradientStart, gradientEnd]),
@@ -28,7 +28,6 @@ struct GradientSurface: ViewModifier {
         }
     }
 }
-
 
 extension View {
     func gradientSurface() -> some View {

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -4,7 +4,9 @@ import SwiftUI
 struct iOSApp: App {
 	var body: some Scene {
 		WindowGroup {
-			ContentView()
+			NavigationView {
+                ContentView()
+            }
 		}
 	}
 }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -2,11 +2,11 @@ import SwiftUI
 
 @main
 struct iOSApp: App {
-	var body: some Scene {
-		WindowGroup {
-			NavigationView {
+    var body: some Scene {
+        WindowGroup {
+            NavigationStack {
                 ContentView()
             }
-		}
-	}
+        }
+    }
 }

--- a/iosApp/iosApp/translate/presentation/IOSTranslateViewModel.swift
+++ b/iosApp/iosApp/translate/presentation/IOSTranslateViewModel.swift
@@ -13,24 +13,30 @@ extension TranslateScreen {
     @MainActor class IOSTranslateViewModel: ObservableObject {
         private var historyDataSource: HistoryDataSource
         private var translateUseCase: TranslateUseCase
-        
-        private let viewModel : TranslateViewModel
-        
+
+        private let viewModel: TranslateViewModel
+
         @Published var state: TranslateState = TranslateState(
             fromText: "",
             toText: nil,
             isTranslating: false,
-            fromLanguage: UiLanguage(language: .english, imagePath: "english.png"),
+            fromLanguage: UiLanguage(
+                language: .english,
+                imagePath: "english.png"
+            ),
             toLanguage: UiLanguage(language: .german, imagePath: "german"),
             isChoosingFromLanguage: false,
-            isChoosingToLanguage: false ,
+            isChoosingToLanguage: false,
             error: nil,
             history: []
         )
-        
+
         private var handle: (any Kotlinx_coroutines_coreDisposableHandle)?
-        
-        init(historyDataSource: HistoryDataSource, translateUseCase: TranslateUseCase) {
+
+        init(
+            historyDataSource: HistoryDataSource,
+            translateUseCase: TranslateUseCase
+        ) {
             self.historyDataSource = historyDataSource
             self.translateUseCase = translateUseCase
             self.viewModel = TranslateViewModel(
@@ -39,21 +45,21 @@ extension TranslateScreen {
                 coroutineScope: nil,
             )
         }
-        
+
         func onEvent(event: TranslateEvent) {
             self.viewModel.onEvent(event: event)
         }
-               
-       func startObserving() {
-           handle = viewModel.state.subscribe(onCollect: {state in
-               if let state = state {
+
+        func startObserving() {
+            handle = viewModel.state.subscribe(onCollect: { state in
+                if let state = state {
                     self.state = state
                 }
-           })
-       }
-               
-       func dispose() {
-           handle?.dispose()
-       }
+            })
+        }
+
+        func dispose() {
+            handle?.dispose()
+        }
     }
 }

--- a/iosApp/iosApp/translate/presentation/TranslateScreen.swift
+++ b/iosApp/iosApp/translate/presentation/TranslateScreen.swift
@@ -86,6 +86,8 @@ struct TranslateScreen: View {
                             viewModel.onEvent(event: .SelectHistoryItem(item: item))
                         }
                     )
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.background)
                 }
 
             }

--- a/iosApp/iosApp/translate/presentation/TranslateScreen.swift
+++ b/iosApp/iosApp/translate/presentation/TranslateScreen.swift
@@ -68,10 +68,45 @@ struct TranslateScreen: View {
                 )
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.background)
+                
+                
+                if !viewModel.state.history.isEmpty {
+                    Text("History")
+                        .font(.title)
+                        .bold()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .listRowSeparator(.hidden)
+                        .listRowBackground(Color.background)
+                }
+                
+                ForEach(viewModel.state.history, id: \.self.id) { item in
+                    TranslateHistoryItem(
+                        item: item,
+                        onClick: {
+                            viewModel.onEvent(event: .SelectHistoryItem(item: item))
+                        }
+                    )
+                }
 
             }
             .listStyle(.plain)
             .buttonStyle(.plain)
+            
+            VStack{
+                Spacer()
+                NavigationLink(
+                    destination: Text("Voice to text screen")
+                ){
+                    ZStack{
+                        Circle()
+                            .foregroundColor(.primaryColor)
+                            .padding()
+                        Image(uiImage: UIImage(named: "mic")!)
+                            .foregroundColor(.onPrimary)
+                    }
+                    .frame(maxWidth: 100, maxHeight: 100)
+                }
+            }
         }
         .onAppear {
             viewModel.startObserving()

--- a/iosApp/iosApp/translate/presentation/TranslateScreen.swift
+++ b/iosApp/iosApp/translate/presentation/TranslateScreen.swift
@@ -10,18 +10,23 @@ import SwiftUI
 import shared
 
 struct TranslateScreen: View {
-    
+
     private var historyDataSource: HistoryDataSource
     private var translateUseCase: TranslateUseCase
     @ObservedObject var viewModel: IOSTranslateViewModel
-    
-    init(historyDataSource: HistoryDataSource, translateUseCase: TranslateUseCase) {
+
+    init(
+        historyDataSource: HistoryDataSource,
+        translateUseCase: TranslateUseCase
+    ) {
         self.historyDataSource = historyDataSource
         self.translateUseCase = translateUseCase
-        self.viewModel = IOSTranslateViewModel(historyDataSource: historyDataSource, translateUseCase: translateUseCase)
+        self.viewModel = IOSTranslateViewModel(
+            historyDataSource: historyDataSource,
+            translateUseCase: translateUseCase
+        )
     }
-    
-    
+
     var body: some View {
         ZStack {
             List {
@@ -30,13 +35,19 @@ struct TranslateScreen: View {
                         language: viewModel.state.fromLanguage,
                         isOpen: viewModel.state.isChoosingFromLanguage,
                         selectedLanguage: { language in
-                            viewModel.onEvent(event: TranslateEvent.ChooseFromLanguage(language: language))
+                            viewModel.onEvent(
+                                event: TranslateEvent.ChooseFromLanguage(
+                                    language: language
+                                )
+                            )
                         }
                     )
                     Spacer()
                     SwapLanguageButton(
                         onClick: {
-                            viewModel.onEvent(event: TranslateEvent.SwapLanguages())
+                            viewModel.onEvent(
+                                event: TranslateEvent.SwapLanguages()
+                            )
                         }
                     )
                     Spacer()
@@ -44,18 +55,24 @@ struct TranslateScreen: View {
                         language: viewModel.state.toLanguage,
                         isOpen: viewModel.state.isChoosingToLanguage,
                         selectedLanguage: { language in
-                            viewModel.onEvent(event: TranslateEvent.ChooseToLanguage(language: language))
+                            viewModel.onEvent(
+                                event: TranslateEvent.ChooseToLanguage(
+                                    language: language
+                                )
+                            )
                         }
                     )
                 }
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.background)
-                
+
                 TranslateTextField(
                     fromText: Binding(
-                        get: { viewModel.state.fromText},
+                        get: { viewModel.state.fromText },
                         set: { value in
-                            viewModel.onEvent(event: .ChangeTranslationText(text: value))
+                            viewModel.onEvent(
+                                event: .ChangeTranslationText(text: value)
+                            )
                         }
                     ),
                     toText: viewModel.state.toText,
@@ -68,8 +85,7 @@ struct TranslateScreen: View {
                 )
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.background)
-                
-                
+
                 if !viewModel.state.history.isEmpty {
                     Text("History")
                         .font(.title)
@@ -78,12 +94,14 @@ struct TranslateScreen: View {
                         .listRowSeparator(.hidden)
                         .listRowBackground(Color.background)
                 }
-                
+
                 ForEach(viewModel.state.history, id: \.self.id) { item in
                     TranslateHistoryItem(
                         item: item,
                         onClick: {
-                            viewModel.onEvent(event: .SelectHistoryItem(item: item))
+                            viewModel.onEvent(
+                                event: .SelectHistoryItem(item: item)
+                            )
                         }
                     )
                 }
@@ -91,13 +109,13 @@ struct TranslateScreen: View {
             }
             .listStyle(.plain)
             .buttonStyle(.plain)
-            
-            VStack{
+
+            VStack {
                 Spacer()
                 NavigationLink(
                     destination: Text("Voice to text screen")
-                ){
-                    ZStack{
+                ) {
+                    ZStack {
                         Circle()
                             .foregroundColor(.primaryColor)
                             .padding()

--- a/iosApp/iosApp/translate/presentation/components/LanguageDisplay.swift
+++ b/iosApp/iosApp/translate/presentation/components/LanguageDisplay.swift
@@ -8,9 +8,10 @@
 
 import SwiftUI
 import shared
+
 struct LanguageDisplay: View {
     var language: UiLanguage
-    
+
     var body: some View {
         HStack {
             SmallLanguageIcon(language: language)
@@ -18,7 +19,7 @@ struct LanguageDisplay: View {
             Text(language.language.name)
                 .foregroundColor(.lightBlue)
         }
-        
+
     }
 }
 

--- a/iosApp/iosApp/translate/presentation/components/LanguageDropdown.swift
+++ b/iosApp/iosApp/translate/presentation/components/LanguageDropdown.swift
@@ -13,24 +13,28 @@ struct LanguageDropdown: View {
     var language: UiLanguage
     var isOpen: Bool
     var selectedLanguage: (UiLanguage) -> Void
-    
+
     var body: some View {
         Menu {
             VStack {
-                ForEach(UiLanguage.Companion().allLanguages, id: \.self.language.code){ language in
+                ForEach(
+                    UiLanguage.Companion().allLanguages,
+                    id: \.self.language.code
+                ) { language in
                     LanguageDropdownItem(
-                        language: language, onClick: {
+                        language: language,
+                        onClick: {
                             selectedLanguage(language)
                         }
                     )
                 }
             }
         } label: {
-            HStack{
+            HStack {
                 SmallLanguageIcon(language: language)
                 Text(language.language.languageName)
                     .foregroundColor(.lightBlue)
-                Image(systemName:  isOpen ? "chevron.up" : "chevron.down")
+                Image(systemName: isOpen ? "chevron.up" : "chevron.down")
                     .foregroundColor(.lightBlue)
             }
         }
@@ -40,7 +44,7 @@ struct LanguageDropdown: View {
 #Preview {
     LanguageDropdown(
         language: UiLanguage(language: .german, imagePath: "german"),
-        isOpen : true,
+        isOpen: true,
         selectedLanguage: { language in }
     )
 }

--- a/iosApp/iosApp/translate/presentation/components/LanguageDropdownItem.swift
+++ b/iosApp/iosApp/translate/presentation/components/LanguageDropdownItem.swift
@@ -10,23 +10,25 @@ import SwiftUI
 import shared
 
 struct LanguageDropdownItem: View {
-    
+
     var language: UiLanguage
     var onClick: () -> Void
-    
+
     var body: some View {
         Button(action: onClick) {
             HStack {
-                
-                if let image = UIImage(named: (language.imagePath?.lowercased())!){
-                        Image(uiImage: image)
+
+                if let image = UIImage(
+                    named: (language.imagePath?.lowercased())!
+                ) {
+                    Image(uiImage: image)
                         .resizable()
                         .frame(width: 40, height: 40)
                         .padding(.trailing, 6)
                     Text(language.language.languageName)
                         .foregroundColor(.textBlack)
                 }
-                
+
             }
         }
     }
@@ -34,6 +36,7 @@ struct LanguageDropdownItem: View {
 
 #Preview {
     LanguageDropdownItem(
-        language: UiLanguage(language: .german, imagePath: "german"), onClick: { }
+        language: UiLanguage(language: .german, imagePath: "german"),
+        onClick: {}
     )
 }

--- a/iosApp/iosApp/translate/presentation/components/ProgressButton.swift
+++ b/iosApp/iosApp/translate/presentation/components/ProgressButton.swift
@@ -10,19 +10,18 @@ import SwiftUI
 import shared
 
 struct ProgressButton: View {
-    
+
     var text: String
     var isLoading: Bool
     var onClick: () -> Void
-    
-    
+
     var body: some View {
         Button(action: {
             if !isLoading {
                 onClick()
             }
         }
-        ){
+        ) {
             if isLoading {
                 ProgressView()
                     .animation(.easeInOut, value: isLoading)
@@ -31,7 +30,7 @@ struct ProgressButton: View {
                     .cornerRadius(100)
                     .progressViewStyle(CircularProgressViewStyle(tint: .white))
             } else {
-                
+
                 Text(text.uppercased())
                     .animation(.easeInOut, value: isLoading)
                     .padding(.horizontal)
@@ -46,6 +45,8 @@ struct ProgressButton: View {
 
 #Preview {
     ProgressButton(
-        text: "Translate", isLoading: false, onClick: {}
+        text: "Translate",
+        isLoading: false,
+        onClick: {}
     )
 }

--- a/iosApp/iosApp/translate/presentation/components/SmallLanguageIcon.swift
+++ b/iosApp/iosApp/translate/presentation/components/SmallLanguageIcon.swift
@@ -11,7 +11,7 @@ import shared
 
 struct SmallLanguageIcon: View {
     var language: UiLanguage
-    
+
     var body: some View {
         Image(uiImage: UIImage(named: language.imagePath?.lowercased() ?? "")!)
             .resizable()

--- a/iosApp/iosApp/translate/presentation/components/SwapLanguageButton.swift
+++ b/iosApp/iosApp/translate/presentation/components/SwapLanguageButton.swift
@@ -6,15 +6,14 @@
 //  Copyright © 2026 orgName. All rights reserved.
 //
 
-
 import SwiftUI
 
 struct SwapLanguageButton: View {
-    
+
     var onClick: () -> Void
-    
+
     var body: some View {
-        Button(action: onClick){
+        Button(action: onClick) {
             Image(uiImage: UIImage(named: "swap_languages")!)
                 .padding()
                 .background(Color.primaryColor)
@@ -26,7 +25,7 @@ struct SwapLanguageButton: View {
 #Preview {
     SwapLanguageButton(
         onClick: {
-            
+
         }
     )
 }

--- a/iosApp/iosApp/translate/presentation/components/TextToSpeech.swift
+++ b/iosApp/iosApp/translate/presentation/components/TextToSpeech.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2026 orgName. All rights reserved.
 //
 
-import Foundation
 import AVFoundation
+import Foundation
 
 struct TextToSpeech {
     private let synthesizer = AVSpeechSynthesizer()
-    
-    func speak(text: String, language: String){
+
+    func speak(text: String, language: String) {
         let utterance = AVSpeechUtterance(string: text)
         utterance.voice = AVSpeechSynthesisVoice(language: language)
         utterance.volume = 1.0

--- a/iosApp/iosApp/translate/presentation/components/TranslateHistoryItem.swift
+++ b/iosApp/iosApp/translate/presentation/components/TranslateHistoryItem.swift
@@ -1,0 +1,63 @@
+//
+//  TranslateHistoryItem.swift
+//  iosApp
+//
+//  Created by Enzo Lizama on 23/02/26.
+//  Copyright © 2026 orgName. All rights reserved.
+//
+
+import SwiftUI
+import shared
+
+struct TranslateHistoryItem: View {
+    var item: UiHistoryItem
+    var onClick: () -> Void
+    
+    
+    var body: some View {
+        Button(action: onClick){
+            VStack(alignment: .leading){
+                HStack {
+                    SmallLanguageIcon(language: item.fromLanguage)
+                        .padding(.trailing)
+                    Text(item.fromText)
+                        .foregroundColor(.lightBlue)
+                        .font(.body)
+                    
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                
+                HStack {
+                    SmallLanguageIcon(language: item.toLanguage)
+                        .padding(.trailing)
+                    Text(item.toText)
+                        .foregroundColor(.onSurface)
+                        .font(.body.weight(.semibold))
+                    
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .gradientSurface()
+            .cornerRadius(15)
+            .shadow(radius: 4)
+        }
+    }
+}
+
+#Preview {
+    TranslateHistoryItem(
+        item: UiHistoryItem(
+            id: 0,
+            fromText: "hELLO",
+            toText: "hOLA",
+            fromLanguage: UiLanguage(language: .english, imagePath: "english"),
+            toLanguage: UiLanguage(language: .spanish, imagePath: "spanish")),
+            onClick: {
+                
+            }
+    )
+}

--- a/iosApp/iosApp/translate/presentation/components/TranslateHistoryItem.swift
+++ b/iosApp/iosApp/translate/presentation/components/TranslateHistoryItem.swift
@@ -12,35 +12,32 @@ import shared
 struct TranslateHistoryItem: View {
     var item: UiHistoryItem
     var onClick: () -> Void
-    
-    
+
     var body: some View {
-        Button(action: onClick){
-            VStack(alignment: .leading){
+        Button(action: onClick) {
+            VStack(alignment: .leading) {
                 HStack {
                     SmallLanguageIcon(language: item.fromLanguage)
                         .padding(.trailing)
                     Text(item.fromText)
                         .foregroundColor(.lightBlue)
                         .font(.body)
-                    
+
                 }
-                .padding()
                 .frame(maxWidth: .infinity, alignment: .leading)
-                
+                .padding()
                 HStack {
                     SmallLanguageIcon(language: item.toLanguage)
                         .padding(.trailing)
                     Text(item.toText)
                         .foregroundColor(.onSurface)
                         .font(.body.weight(.semibold))
-                    
+
                 }
                 .padding()
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             .frame(maxWidth: .infinity)
-            .padding()
             .gradientSurface()
             .cornerRadius(15)
             .shadow(radius: 4)
@@ -55,9 +52,10 @@ struct TranslateHistoryItem: View {
             fromText: "hELLO",
             toText: "hOLA",
             fromLanguage: UiLanguage(language: .english, imagePath: "english"),
-            toLanguage: UiLanguage(language: .spanish, imagePath: "spanish")),
-            onClick: {
-                
-            }
+            toLanguage: UiLanguage(language: .spanish, imagePath: "spanish")
+        ),
+        onClick: {
+
+        }
     )
 }

--- a/iosApp/iosApp/translate/presentation/components/TranslateHistoryItem.swift
+++ b/iosApp/iosApp/translate/presentation/components/TranslateHistoryItem.swift
@@ -52,8 +52,8 @@ struct TranslateHistoryItem: View {
     TranslateHistoryItem(
         item: UiHistoryItem(
             id: 0,
-            fromText: "hELLO",
-            toText: "hOLA",
+            fromText: "Hello",
+            toText: "Hola",
             fromLanguage: UiLanguage(language: .english, imagePath: "english"),
             toLanguage: UiLanguage(language: .spanish, imagePath: "spanish")),
             onClick: {

--- a/iosApp/iosApp/translate/presentation/components/TranslateTextField.swift
+++ b/iosApp/iosApp/translate/presentation/components/TranslateTextField.swift
@@ -94,7 +94,7 @@ extension TranslateTextField {
                     .padding(.bottom)
                 }
                 .onAppear {
-                    UITextField.appearance().backgroundColor = .clear
+                    UITextView.appearance().backgroundColor = .clear
                 }
         }
 

--- a/iosApp/iosApp/translate/presentation/components/TranslateTextField.swift
+++ b/iosApp/iosApp/translate/presentation/components/TranslateTextField.swift
@@ -7,25 +7,29 @@
 //
 
 import SwiftUI
-import shared
 import UniformTypeIdentifiers
+import shared
 
 struct TranslateTextField: View {
-    
+
     @Binding var fromText: String
     let toText: String?
     let isTranslating: Bool
     let fromLanguage: UiLanguage
     let toLanguage: UiLanguage
     let onTranslateEvent: (TranslateEvent) -> Void
-    
+
     var body: some View {
         if toText == nil || isTranslating {
-            IdleTextField(fromText: $fromText, isTranslating: isTranslating, onTranslateEvent: onTranslateEvent)
-                .gradientSurface()
-                .cornerRadius(15)
-                .animation(.easeInOut, value:isTranslating)
-                .shadow(radius: 4)
+            IdleTextField(
+                fromText: $fromText,
+                isTranslating: isTranslating,
+                onTranslateEvent: onTranslateEvent
+            )
+            .gradientSurface()
+            .cornerRadius(15)
+            .animation(.easeInOut, value: isTranslating)
+            .shadow(radius: 4)
         } else {
             TranslatedTextField(
                 fromText: fromText,
@@ -49,27 +53,27 @@ struct TranslateTextField: View {
 #Preview {
     TranslateTextField(
         fromText: Binding(
-            get: {"test"},
-            set: { value in}
+            get: { "test" },
+            set: { value in }
         ),
         toText: "Test",
         isTranslating: false,
         fromLanguage: UiLanguage(language: .english, imagePath: "english"),
         toLanguage: UiLanguage(language: .german, imagePath: "german"),
         onTranslateEvent: { event in
-            
+
         }
     )
 }
 
-private extension TranslateTextField {
-    
-    struct IdleTextField: View {
+extension TranslateTextField {
+
+    fileprivate struct IdleTextField: View {
         @Binding var fromText: String
         let isTranslating: Bool
         let onTranslateEvent: (TranslateEvent) -> Void
-        
-        var body: some View{
+
+        var body: some View {
             TextEditor(text: $fromText)
                 .frame(
                     maxWidth: .infinity,
@@ -78,7 +82,7 @@ private extension TranslateTextField {
                 )
                 .padding()
                 .foregroundColor(Color.onSurface)
-                .overlay(alignment: .bottomTrailing){
+                .overlay(alignment: .bottomTrailing) {
                     ProgressButton(
                         text: "Translate",
                         isLoading: isTranslating,
@@ -89,86 +93,94 @@ private extension TranslateTextField {
                     .padding(.trailing)
                     .padding(.bottom)
                 }
-                .onAppear() {
+                .onAppear {
                     UITextField.appearance().backgroundColor = .clear
                 }
+        }
+
+    }
+}
+
+struct TranslatedTextField: View {
+    let fromText: String
+    let toText: String
+    let fromLanguage: UiLanguage
+    let toLanguage: UiLanguage
+    let onTranslateEvent: (TranslateEvent) -> Void
+
+    private let tts = TextToSpeech()
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            LanguageDisplay(language: fromLanguage)
+            Text(fromText)
+                .foregroundColor(.onSurface)
+
+            HStack {
+                Spacer()
+                Button(
+                    action: {
+                        UIPasteboard.general.setValue(
+                            fromText,
+                            forPasteboardType: UTType.plainText.identifier
+                        )
+                    }
+                ) {
+                    Image(uiImage: UIImage(named: "copy")!)
+                        .renderingMode(.template)
+                        .foregroundColor(.lightBlue)
+
+                }
+
+                Button(
+                    action: {
+                        onTranslateEvent(.CloseTranslation())
+                    }
+                ) {
+                    Image(systemName: "xmark")
+                        .foregroundColor(.lightBlue)
+
+                }
             }
-    
+
+            Divider().padding()
+
+            LanguageDisplay(language: toLanguage)
+                .padding(.bottom)
+
+            Text(toText)
+                .foregroundColor(.onSurface)
+
+            HStack {
+                Spacer()
+                Button(
+                    action: {
+                        UIPasteboard.general.setValue(
+                            toText,
+                            forPasteboardType: UTType.plainText.identifier
+                        )
+                    }
+                ) {
+                    Image(uiImage: UIImage(named: "copy")!)
+                        .renderingMode(.template)
+                        .foregroundColor(.lightBlue)
+
+                }
+
+                Button(
+                    action: {
+                        tts.speak(
+                            text: toText,
+                            language: toLanguage.language.code
+                        )
+                    }
+                ) {
+                    Image(systemName: "speaker.wave.2")
+                        .foregroundColor(.lightBlue)
+
+                }
+            }
+
         }
     }
-
-    struct TranslatedTextField: View {
-        let fromText: String
-        let toText: String
-        let fromLanguage: UiLanguage
-        let toLanguage: UiLanguage
-        let onTranslateEvent: (TranslateEvent) -> Void
-        
-        private let tts = TextToSpeech()
-        
-        
-        var body: some View {
-            VStack(alignment: .leading){
-                LanguageDisplay(language: fromLanguage)
-                Text(fromText)
-                    .foregroundColor(.onSurface)
-                
-                HStack{
-                    Spacer()
-                    Button(
-                        action: {
-                            UIPasteboard.general.setValue(fromText, forPasteboardType: UTType.plainText.identifier)
-                        }
-                    ){
-                        Image(uiImage: UIImage(named: "copy")!)
-                            .renderingMode(.template)
-                            .foregroundColor(.lightBlue)
-                        
-                    }
-                    
-                    Button(
-                        action: {
-                            onTranslateEvent(.CloseTranslation())
-                        }
-                    ){
-                        Image(systemName: "xmark")
-                            .foregroundColor(.lightBlue)
-                        
-                    }
-                }
-                
-                Divider().padding()
-                
-                LanguageDisplay(language: toLanguage)
-                    .padding(.bottom)
-                
-                Text(toText)
-                    .foregroundColor(.onSurface)
-                
-                HStack{
-                    Spacer()
-                    Button(
-                        action: {
-                            UIPasteboard.general.setValue(toText, forPasteboardType: UTType.plainText.identifier)
-                        }
-                    ){
-                        Image(uiImage: UIImage(named: "copy")!)
-                            .renderingMode(.template)
-                            .foregroundColor(.lightBlue)
-                        
-                    }
-                    
-                    Button(
-                        action: {
-                            tts.speak(text: toText, language: toLanguage.language.code)
-                        }
-                    ){
-                        Image(systemName: "speaker.wave.2")
-                            .foregroundColor(.lightBlue)
-                        
-                    }
-                }
-                
-            }
-        }
 }


### PR DESCRIPTION
This pull request adds a new `TranslateHistoryItem` UI component and integrates translation history display into the main translation screen. It also introduces some structural and visual improvements to the iOS app, including navigation and background styling.

**UI and Navigation Improvements:**

* Wrapped `ContentView` in a `ZStack` to apply a background color across the entire app for a more consistent look. (`iosApp/iosApp/ContentView.swift`)
* Embedded `ContentView` in a `NavigationView` to enable navigation features throughout the app. (`iosApp/iosApp/iOSApp.swift`)

**Translation History Feature:**

* Added a new `TranslateHistoryItem` SwiftUI component to display individual translation history entries, including language icons and text. (`iosApp/iosApp/translate/presentation/components/TranslateHistoryItem.swift`)
* Updated `TranslateScreen` to show a "History" section and render a list of `TranslateHistoryItem` components for each history entry. Also added a floating microphone button that navigates to a placeholder "Voice to text screen". (`iosApp/iosApp/translate/presentation/TranslateScreen.swift`)

**Project Structure Updates:**

* Registered the new `TranslateHistoryItem.swift` file in the Xcode project, ensuring it is included in the build and grouped with other UI components. (`iosApp/iosApp.xcodeproj/project.pbxproj`) [[1]](diffhunk://#diff-3128a88752afa7f03b453c0c30cbc563d3998b87fc54a1267bd1f1c943341d87R27) [[2]](diffhunk://#diff-3128a88752afa7f03b453c0c30cbc563d3998b87fc54a1267bd1f1c943341d87R51) [[3]](diffhunk://#diff-3128a88752afa7f03b453c0c30cbc563d3998b87fc54a1267bd1f1c943341d87R161) [[4]](diffhunk://#diff-3128a88752afa7f03b453c0c30cbc563d3998b87fc54a1267bd1f1c943341d87R325)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Translation history section with clickable, styled history cards for quick reuse.
  * Floating voice-to-text button that navigates to a voice input screen.
  * App now uses a navigation container and a full-screen background for improved layout.

* **Improvements**
  * Text-to-speech playback now triggers audio output for translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->